### PR TITLE
New release 0.3.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,10 @@
+# Changelog
+## [0.3.2] - 2023-01-29
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Use latest rust-netlink crates. (fc3dc0c)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netlink-packet-generic"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Leo <leo881003@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/rust-netlink/netlink-packet-generic"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - Use latest rust-netlink crates. (fc3dc0c)