### PR TITLE
Include NLA header on mcast groups and ops.

### DIFF
--- a/src/ctrl/nlas/ops.rs
+++ b/src/ctrl/nlas/ops.rs
@@ -44,7 +44,7 @@ pub struct Op {
 
 impl Nla for Op {
     fn value_len(&self) -> usize {
-        self.nlas.iter().map(|nla| nla.buffer_len()).sum()
+        self.nlas.as_slice().buffer_len()
     }
 
     fn kind(&self) -> u16 {

--- a/src/ctrl/nlas/ops.rs
+++ b/src/ctrl/nlas/ops.rs
@@ -4,12 +4,41 @@ use crate::constants::*;
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
-    nla::{Nla, NlaBuffer},
+    nla::{Nla, NlaBuffer, NlasIterator, NLA_F_NESTED},
     parsers::*,
     traits::*,
     DecodeError,
 };
 use std::mem::size_of_val;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Op {
+    pub nlas: Vec<OpAttrs>,
+}
+
+impl Nla for Op {
+    fn value_len(&self) -> usize {
+        self.nlas.iter().map(|nla| nla.buffer_len()).sum()
+    }
+
+    fn kind(&self) -> u16 {
+        NLA_F_NESTED
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        self.nlas.as_slice().emit(buffer);
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Op {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        let nlas = NlasIterator::new(payload)
+            .map(|nla| nla.and_then(|nla| OpAttrs::parse(&nla)))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { nlas })
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OpAttrs {


### PR DESCRIPTION
The emit logic for McastGroups doesn't include the required NLA header on nested NLAs. Without this change, netlink-packet-generic emits incorrect buffers if an mcast group is included, and cannot parse the bytes it writes.