### PR TITLE
Fix for example 'list_generic_family.rs'. 

### DIFF
--- a/examples/list_generic_family.rs
+++ b/examples/list_generic_family.rs
@@ -28,7 +28,7 @@ fn main() {
 
     socket.send(&txbuf, 0).unwrap();
 
-    let mut rxbuf = vec![0u8; 4096];
+    let mut rxbuf = Vec::with_capacity(4096);
     let mut offset = 0;
 
     'outer: loop {


### PR DESCRIPTION
The rxbuf cannot contain zeros before receiving data. The buffer must be cleared.