### PR TITLE
Fix list_generic_family example

### DIFF
--- a/examples/list_generic_family.rs
+++ b/examples/list_generic_family.rs
@@ -28,11 +28,11 @@ fn main() {
 
     socket.send(&txbuf, 0).unwrap();
 
-    let mut rxbuf = Vec::with_capacity(4096);
+    let mut rxbuf = Vec::with_capacity(8192);
     let mut offset = 0;
-
+    let mut size = 0;
     'outer: loop {
-        let size = socket.recv(&mut rxbuf, 0).unwrap();
+        size += socket.recv(&mut rxbuf, 0).unwrap();
 
         loop {
             let buf = &rxbuf[offset..];
@@ -56,7 +56,6 @@ fn main() {
 
             offset += msg.header.length as usize;
             if offset == size || msg.header.length == 0 {
-                offset = 0;
                 break;
             }
         }


### PR DESCRIPTION
* I've increased the capacity as on my system 4096 bytes weren't enough.
* `offset = 0` resulted into printing previous messages again
* `size` must also be accumulated over mutliple `socket.recv`. Otherwise `offset > size`, which means, the loop would never break. 