### PR TITLE
New release 0.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,15 @@
 # Changelog
+## [0.4.0] - 2025-08-27
+### Breaking changes
+ - Use `netlink-packet-core 0.8`. No API changed, just bump version
+   forcing manual intervention on all dependency chain update. (4f5da61)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - N/A
+
 ## [0.3.3] - 2023-07-09
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "netlink-packet-generic"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Leo <leo881003@gmail.com>"]
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/rust-netlink/netlink-packet-generic"
 repository = "https://github.com/rust-netlink/netlink-packet-generic"
 keywords = ["netlink", "linux"]


### PR DESCRIPTION
=== Breaking changes
 - Use `netlink-packet-core 0.8`. No API changed, just bump version
   forcing manual intervention on all dependency chain update. (4f5da61)

=== New features
 - N/A

=== Bug fixes
 - N/A